### PR TITLE
Connect round timer to guns and buildings

### DIFF
--- a/src/shared/Building.lua
+++ b/src/shared/Building.lua
@@ -70,7 +70,7 @@ function Building:_replace(with)
 	clone.Parent = self.model
 end
 
-function Building:_changeVersion(version: VERSION)
+function Building:changeVersion(version: VERSION)
 	if version == Building.NEW then
 		self:_replace(self.model.NewVersion.Value)
 	else
@@ -79,7 +79,7 @@ function Building:_changeVersion(version: VERSION)
 end
 
 function Building:initServer()
-	self:_changeVersion(Building.NEW)
+	self:changeVersion(Building.NEW)
 	self.model:SetAttribute("Stability", 100)
 end
 
@@ -103,11 +103,11 @@ function Building:applyChange(value: number)
 		if value < 0 then
 			stability = -50
 			self.model:SetAttribute("Flux", -10)
-			self:_changeVersion(Building.OLD)
+			self:changeVersion(Building.OLD)
 		else
 			stability = 50
 			self.model:SetAttribute("Flux", 10)
-			self:_changeVersion(Building.NEW)
+			self:changeVersion(Building.NEW)
 		end
 	else
 		-- If stability and value are the same sign

--- a/src/shared/GameManager.lua
+++ b/src/shared/GameManager.lua
@@ -109,11 +109,28 @@ local function onPlayerAdded(player)
 	player.CharacterRemoving:Connect(onCharacterRemovingServer)
 end
 
+local function startRound()
+    for _, building in buildings do
+        building:changeVersion(Building.NEW)
+    end
+
+    for _, player in Players:GetPlayers() do
+        player:LoadCharacter()
+    end
+end
+
+local function endRound()
+    -- Nothing at the moment
+end
+
 local function initServer()
 	Players.PlayerAdded:Connect(onPlayerAdded)
 
 	timer = RoundTimer.new(ROUND_TIME, WAIT_TIME)
 	timer:initServer()
+
+    timer.onStart.Event:Connect(startRound)
+    timer.onStop.Event:Connect(endRound)
 
 	for _, part in workspace:GetChildren() do
 		if part:IsA("Model") and part:FindFirstChild("OldVersion") then

--- a/src/shared/GameManager.lua
+++ b/src/shared/GameManager.lua
@@ -111,7 +111,7 @@ end
 
 local function startRound()
     for _, building in buildings do
-        building:changeVersion(Building.NEW)
+        building:initServer()
     end
 
     for _, player in Players:GetPlayers() do

--- a/src/shared/Gun.lua
+++ b/src/shared/Gun.lua
@@ -97,7 +97,7 @@ end
 
 function Gun:connectToServerEvent()
 	local function onServerEvent(player, enabled, pos)
-		if not workspace:GetAttribute("Running") then
+		if enabled and not workspace:GetAttribute("Running") then
 			return
 		end
 

--- a/src/shared/Gun.lua
+++ b/src/shared/Gun.lua
@@ -58,7 +58,7 @@ end
 function Gun:setEnable(enabled: boolean)
 	self.enabled = enabled
 	self.event:FireServer(enabled)
-	while self.enabled do
+	while self.enabled and workspace:GetAttribute("Running") do
 		self:_tick()
 		task.wait(TICK_RATE)
 	end
@@ -94,7 +94,12 @@ end
 
 function Gun:connectToServerEvent()
 	local function onServerEvent(player, enabled, pos)
+		if not workspace:GetAttribute("Running") then
+			return
+		end
+
 		self:setColor(player.Team.TeamColor.Color)
+		self.enabled = enabled
 		self:setBeamEnabled(enabled)
 		if enabled and pos then
 			local result = workspace:Raycast(self.handle.Position, (pos - self.handle.Position) * 1.1)
@@ -110,8 +115,22 @@ function Gun:connectToServerEvent()
 			self.onStop:Fire(self.handle)
 		end
 	end
-
+	
+	local function onRunningChanged(attr)
+		if attr ~= "Running" then
+			return
+		end
+		if not workspace:GetAttribute("Running") then
+			if self.enabled then
+				self.onStop:Fire(self.handle)
+			end
+			self.enabled = false
+			self:setBeamEnabled(false)
+		end
+	end
+	
 	self:_connect(self.event.OnServerEvent, onServerEvent)
+	workspace.AttributeChanged:Connect(onRunningChanged)
 end
 
 return Gun

--- a/src/shared/Gun.lua
+++ b/src/shared/Gun.lua
@@ -58,9 +58,12 @@ end
 function Gun:setEnable(enabled: boolean)
 	self.enabled = enabled
 	self.event:FireServer(enabled)
-	while self.enabled and workspace:GetAttribute("Running") do
-		self:_tick()
-		task.wait(TICK_RATE)
+	if enabled then
+		while self.enabled and workspace:GetAttribute("Running") do
+			self:_tick()
+			task.wait(TICK_RATE)
+		end
+		self.event:FireServer(false)
 	end
 end
 


### PR DESCRIPTION
Disable guns while the round isn't running and reset players and buildings at the start of a round. (Buildings just reset to one form for now, but should be randomized.)