### PR TITLE
Fix weld not being visible to the server

### DIFF
--- a/src/shared/GameManager.lua
+++ b/src/shared/GameManager.lua
@@ -84,6 +84,14 @@ local function onPlayerAdded(player)
 
 	local function onCharacterAddedServer(character)
 		local gunModel = character.Gun
+		gunModel.AncestryChanged:Connect(function(child, parent)
+			if parent == workspace then
+				gunModel.Handle.WeldConstraint.Part1 = character.RightHand
+				gunModel.Handle.Position = character.RightHand.Position
+				gunModel.Handle:SetNetworkOwner(player)
+			end
+		end)
+
 		gun = GunScript.new(gunModel.Handle, gunModel.Target, Convert)
 		gun:connectToServerEvent()
 		gun.onHit.Event:Connect(hitBuilding)


### PR DESCRIPTION
The weld script as is doesn't replicate the change to the server, but simply setting the weld on the server doesn't work either. This instead waits until the character is parented to the workspace to then set the gun's network owner to the client.