### PR TITLE
Add a little code to enable spawns in changing buildings.

### DIFF
--- a/src/shared/Building.lua
+++ b/src/shared/Building.lua
@@ -67,6 +67,13 @@ function Building:_replace(with)
 	clone:SetPrimaryPartCFrame(self.model.PrimaryPart.CFrame)
 	clone.PrimaryPart:Destroy()
 	clone.Name = "Building"
+
+	-- Assumes at most one spawn per building
+	local spawn = clone:FindFirstChildWhichIsA("SpawnLocation", true)
+	if spawn then
+		spawn.Enabled = true
+	end
+
 	clone.Parent = self.model
 end
 


### PR DESCRIPTION
This allows for disabled SpawnLocations to be added to the building templates to be enabled when those templates are cloned into the play area.