### PR TITLE
Use NumberValue for building change rate

### DIFF
--- a/src/shared/Gun.lua
+++ b/src/shared/Gun.lua
@@ -97,10 +97,6 @@ end
 
 function Gun:connectToServerEvent()
 	local function onServerEvent(player, enabled, pos)
-		if not self.handle:IsDescendantOf(player.Character) then
-			return
-		end
-
 		if enabled and not workspace:GetAttribute("Running") then
 			return
 		end

--- a/src/shared/Gun.lua
+++ b/src/shared/Gun.lua
@@ -97,6 +97,10 @@ end
 
 function Gun:connectToServerEvent()
 	local function onServerEvent(player, enabled, pos)
+		if not self.handle:IsDescendantOf(player.Character) then
+			return
+		end
+
 		if enabled and not workspace:GetAttribute("Running") then
 			return
 		end


### PR DESCRIPTION
Uses ReplicatedStorage.ChangeRate to set the rate at which buildings are changed by the beams. Also refactor some of the math to better work with non-integer values.